### PR TITLE
Fixup for workflows

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -6,17 +6,8 @@ on:
   push:
     branches:
       - "*"
-    paths:
-      - "src/**"
-      - "Cargo.*"
-      - build.rs
   pull_request:
     branches: ["main"]
-    paths:
-      - ".github/workflows/tests.yml"
-      - "src/**"
-      - "Cargo.*"
-      - build.rs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -44,7 +35,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.0
+
+      - name: Set up Ruby on Windows
+        if: runner.os == 'Windows'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          msys2: true
+
+      - name: Install pre-commit dependencies
+        run: python -m pip install pre-commit
+
+      - uses: pre-commit/action@v3.0.1
         name: Run pre-commit hooks
 
       - name: Run Rust tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provide a thin wrapper type around the [compile_commands.json](https://clang.llv
 and  [compile_flags.txt](https://clang.llvm.org/docs/JSONCompilationDatabase.html#alternatives)
 standards as provided by the LLVM project.
 
-## Sample usage:
+## Sample usage
 
 Given the following `compile_commands.json` file:
 


### PR DESCRIPTION
Removes the file path restrictions for workflows to run, cleans up `README.md`.